### PR TITLE
I did what the error message told me to do: WARNING:  open-ended depe…

### DIFF
--- a/logstash-filter-math.gemspec
+++ b/logstash-filter-math.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
 
-  s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'logstash-devutils', '~> 0'
 end
 


### PR DESCRIPTION
…ndency on logstash-devutils (>= 0, development) is not recommended   if logstash-devutils is semantically versioned, use:     add_development_dependency 'logstash-devutils', '~> 0' WARNING:  See http://guides.rubygems.org/specification-reference/ for help

Now the gem compiles without warnings.